### PR TITLE
feat: limit number of results to reduce choppiness

### DIFF
--- a/src/bazaarclient.cpp
+++ b/src/bazaarclient.cpp
@@ -10,6 +10,9 @@
 
 using namespace Qt::Literals::StringLiterals;
 
+// TODO: make this configurable in a KCM
+static constexpr int kMaxNumResults = 6;
+
 QString kDBusServiceName = QStringLiteral("io.github.kolunmi.Bazaar");
 QString kDBusServicePath = QStringLiteral("/io/github/kolunmi/Bazaar/SearchProvider");
 QString kDBusServiceInterface = QStringLiteral("org.gnome.Shell.SearchProvider2");
@@ -119,7 +122,11 @@ QList<AppSuggestion> BazaarClient::search(const QString &term, const std::functi
         return results;
     }
 
-    qDebug() << "BazaarClient::search: Bazaar returned" << resultIds.size() << "result IDs:" << resultIds;
+    qDebug() << "BazaarClient::search: Bazaar returned" << resultIds.size() << "result IDs (will be truncated to " << kMaxNumResults << ")";
+
+    if (resultIds.size() > kMaxNumResults) {
+        resultIds = resultIds.mid(0, kMaxNumResults);
+    }
 
     QList<QVariantMap> metas = getResultMetas(resultIds);
 


### PR DESCRIPTION
The application launcher suffers from micro-stutters when the user types 3 characters. This is because Bazaar often returns 100+ results for short queries and adding all results to the match list causes noticeable lag in the UI.

This PR limits the number of results to 6 to fix the stuttering. In the future, I would like to make this value configurable in a KCM, but that is not a high priority at the moment.

## Before

[Screencast_20250713_042605.webm](https://github.com/user-attachments/assets/c4a7a123-5317-4637-8560-51d8598da695)

## After

[Screencast_20250713_042932.webm](https://github.com/user-attachments/assets/a2a802e9-4520-4ad8-9062-7c42ee0eb56b)

