### PR TITLE
feat: flatpak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,4 +22,6 @@ ki18n_install(po)
 
 add_subdirectory(src)
 
+install(FILES io.github.ublueos.bazaarrunner.desktop DESTINATION ${KDE_INSTALL_DATAROOTDIR}/krunner/dbusplugins)
+
 feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/Justfile
+++ b/Justfile
@@ -32,6 +32,21 @@ build: build-container
             make -j$(nproc)
         '
 
+build-flatpak:
+  #!/usr/bin/env bash
+  flatpak run org.flatpak.Builder \
+    --force-clean \
+    --install \
+    --install-deps-from=flathub \
+    --user \
+    --verbose \
+    --ccache \
+    --disable-updates \
+    --keep-build-dirs \
+    build \
+    ./io.github.ublueos.bazaarrunner.yaml
+
+
 install: build
     #!/usr/bin/env bash
     set -euo pipefail

--- a/io.github.ublueos.bazaarrunner.desktop
+++ b/io.github.ublueos.bazaarrunner.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=Krunner-Bazaar Flatpak
+X-KDE-ServiceTypes=Plasma/Runner
+Comment=this is not using the json file provided by krunner-bazaar, metadata is broken on every KDE and non KDE app btw
+Type=Service
+Icon=io.github.kolunmi.Bazaar
+X-KDE-ServiceTypes=Plasma/Runner
+X-KDE-PluginInfo-Name=bazaarrunner
+X-KDE-PluginInfo-EnabledByDefault=true
+X-Plasma-API=DBus
+X-Plasma-DBusRunner-Service=io.github.kolunmi.Bazaar
+X-Plasma-DBusRunner-Path=/io/github/kolunmi/Bazaar/SearchProvider

--- a/io.github.ublueos.bazaarrunner.yaml
+++ b/io.github.ublueos.bazaarrunner.yaml
@@ -1,0 +1,24 @@
+id: io.github.ublueos.bazaarrunner
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+finish-args:
+  - --talk-name=io.github.kolunmi.Bazaar.*
+
+modules:
+  - name: krunner-bazaar
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    buildsystem: cmake-ninja
+    sources:
+      - type: dir
+        path: .
+
+    modules:
+      - name: krunner
+        buildsystem: cmake-ninja
+        sources:
+        - type: git
+          url: https://invent.kde.org/frameworks/krunner
+          tag: v6.22.0
+          commit: bfe9f124da65472f05514198777d80c53ce8a4e6


### PR DESCRIPTION
this doesn't work currently, there is some fuckery going on with the search functionality specifically

for some reason it wants to look in another path, just type anything in kickoff and you get this:
```
plasmashell[162604]: Error requesting matches; calling "io.github.kolunmi.Bazaar"  : "org.qtproject.QtDBus.Error.InvalidObjectPath" "Invalid object path: /SearchProvider/org.gnome.Shell.SearchProvider2"
```

be sure to remove the krunner-bazaar rpm beforehand and logout so we are absolutely sure that none of the stuff from the rpm is still running.

`flatpak run io.github.ublueos.bazaarrunner --search spotify` works

 
<img width="1329" height="348" alt="image" src="https://github.com/user-attachments/assets/aebaeaf8-b937-47f7-a167-9692b2fd1b9f" />

Currently there is only one flatpak kde application that has working krunner integration
(that I know of)
See: https://invent.kde.org/utilities/kclock/-/merge_requests/231
not in a stable release yet

non-kde app:
[gonnect](https://github.com/gonicus/gonnect/blob/main/src/dbus/KRunnerAdapter.cpp)

https://github.com/kolunmi/bazaar/issues/671

I would appreciate help with this one.