### PR TITLE
fix: builds need kf6-kconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,15 @@ set(KF_MIN_VERSION "6.0.0")
 
 find_package(ECM ${KF_MIN_VERSION} REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
-find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui DBus)
-find_package(KF6 ${KF_MIN_VERSION} REQUIRED COMPONENTS Runner I18n)
 
 include(KDEInstallDirs)
 include(KDEClangFormat)
 include(KDECMakeSettings)
 include(KDECompilerSettings NO_POLICY_SCOPE)
 include(FeatureSummary)
+
+find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui DBus)
+find_package(KF6 ${KF_MIN_VERSION} REQUIRED COMPONENTS Runner I18n Config)
 
 find_package(KF6I18n NO_MODULE)
 ki18n_install(po)

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:42
+FROM quay.io/fedora/fedora:latest
 
 LABEL description="Development environment for krunner-bazaar KDE plugin"
 LABEL maintainer="Adam Fidel <adam@fidel.cloud>"
@@ -16,6 +16,7 @@ RUN dnf5 update -y && \
         rpmdevtools \
         # KDE Frameworks 6 development packages
         extra-cmake-modules \
+        kf6-kconfig-devel \
         kf6-krunner-devel \
         kf6-ki18n-devel \
         kf6-kcoreaddons-devel \

--- a/krunner-bazaar.spec
+++ b/krunner-bazaar.spec
@@ -10,6 +10,7 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  cmake
 BuildRequires:  gcc-c++
 BuildRequires:  extra-cmake-modules
+BuildRequires:  kf6-kconfig-devel
 BuildRequires:  kf6-krunner-devel
 BuildRequires:  kf6-ki18n-devel
 BuildRequires:  kf6-kcoreaddons-devel


### PR DESCRIPTION
This seemed to be the minimal change needed to get builds working again. See https://github.com/ublue-os/krunner-bazaar/issues/40.

Changelog:
- Add explicitly required `Config` component for KF6.
- Add `kf6-kconfig-devel` build requirement.
- Move KDE includes to be before Qt6/KF6 `find_package` directives.